### PR TITLE
Fix issue with upload url

### DIFF
--- a/.github/workflows/release-adaptor-container-image.yml
+++ b/.github/workflows/release-adaptor-container-image.yml
@@ -9,6 +9,9 @@ on:
       folder:
         required: true
         type: string
+      upload_url:
+        required: true
+        type: string
 
 jobs:
   reusable_workflow_job:
@@ -39,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ inputs.upload_url }}
           asset_path: ./artifacts/sbom-spdx.json
           asset_name: sbom-spdx.json
           asset_content_type: application/json


### PR DESCRIPTION
* Upload url was using GitHub events to retrieve the upload url, however, this is not present in a reusable workflow.  Instead, we will now pass this in as a required input.